### PR TITLE
Drag both ways + amounts

### DIFF
--- a/lab-Combine/client.lua
+++ b/lab-Combine/client.lua
@@ -1,7 +1,8 @@
 RegisterNetEvent('lab-Combine:Combine', function(duration)
+    TriggerServerEvent('ox_inventory:closeInventory')
     local result = lib.progressCircle({
         duration = duration,
-        label = 'Crafting..',
+        label = 'Combining..',
         position = 'middle',
         useWhileDead = false,
         canCancel = true,
@@ -14,5 +15,6 @@ RegisterNetEvent('lab-Combine:Combine', function(duration)
         },
     })
 
-    lib.callback('srp-dragCraft:success', false, function() end, result)
+    lib.callback('lab-Combine:success', false, function()
+    end, result)
 end)

--- a/lab-Combine/client.lua
+++ b/lab-Combine/client.lua
@@ -1,11 +1,10 @@
-RegisterNetEvent('lab-Combine:Combine')
-AddEventHandler('lab-Combine:Combine', function()
-    lib.progressCircle({
-        duration = 2000,
-        label = 'Combining..',
+RegisterNetEvent('lab-Combine:Combine', function(duration)
+    local result = lib.progressCircle({
+        duration = duration,
+        label = 'Crafting..',
         position = 'middle',
         useWhileDead = false,
-        canCancel = false,
+        canCancel = true,
         disable = {
             car = true,
         },
@@ -14,4 +13,6 @@ AddEventHandler('lab-Combine:Combine', function()
             clip = 'base'
         },
     })
+
+    lib.callback('srp-dragCraft:success', false, function() end, result)
 end)

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -1,29 +1,73 @@
 local ox_inventory = exports.ox_inventory
 
-local Combinations = {
- -- ['item you drag'] = {needs = 'item you drag on to', result = 'result item'},
-	['coca'] = {needs = 'baggy', result = 'coke'},
-    ['meth'] = {needs = 'baggy', result = 'packagedmeth'},
+---@type table<string, { amount: table<string, number>, otherItem: string, duration: number, result: string }>
+local Combinations = { --create new item craft Recipies here. limited to 2 items per craft, but you can have multiple of each of those 2 items if desired
+
+    ['coca'] = { --item1
+	otherItem = 'baggy', --item2
+        amount = {['baggy'] = 1, ['coca'] = 1}, --amount of each item needed to craft. must match item1 and item2
+        duration = 2000, --how long the craft takes
+        result = 'coke' -- the item you get after craft
+    },
+	
+    ['meth'] = { --item1
+	otherItem = 'baggy', --item2
+        amount = {['baggy'] = 1, ['meth'] = 1}, --amount of each item needed to craft. must match item1 and item2
+        duration = 2000, --how long the craft takes
+        result = 'packagedmeth' -- the item you get after craft
+    },
+    
 }
 
-local combhook = ox_inventory:registerHook('swapItems', function(payload)
-    if payload.fromSlot ~= nil and payload.toSlot ~= nil then
-        local item1 = (Combinations[payload.fromSlot.name] and payload.fromSlot.name) or (Combinations[payload.toSlot.name] and payload.toSlot.name)
+local craftHook = exports.ox_inventory:registerHook('swapItems', function(data)
+    if type(data.fromSlot) == "table" and type(data.toSlot) == "table" then
 
+        if data.fromSlot?.name == data.toSlot?.name then return end
+
+        local item1 = (Combinations[data.fromSlot?.name] and data?.fromSlot) or (Combinations[data.toSlot?.name] and data.toSlot)
         if not item1 then return end
 
-        local item2 = (Combinations[item1].needs == payload.fromSlot.name and payload.fromSlot.name) or (Combinations[item1].needs == payload.toSlot.name and payload.toSlot.name)
+        if Combinations[item1.name].amount[item1.name] > item1.count then
+            TriggerClientEvent('ox_lib:notify', data.source,
+            {
+                type = 'error',
+                description = ("Not enough %s. Need %.0f"):format(item1.label, Combinations[item1.name].amount[item1.name])
+            })
+            return false
+        end
+
+        local item2 = (Combinations[item1.name].otherItem == data.fromSlot.name and data.fromSlot) or (Combinations[item1.name].otherItem == data.toSlot.name and data.toSlot)
         if not item2 then return end
 
-        if Combinations[payload.fromSlot.name] then
-            item1 = payload.fromSlot.name
+        if Combinations[item1.name].amount[item2.name] > item2.count then
+            TriggerClientEvent('ox_lib:notify', data.source,
+            {
+                type = 'error',
+                description = ("Not enough %s. Need %.0f"):format(item2.label, Recipies[item1.name].amount[item2.name])
+            })
+            return false
         end
-        TriggerClientEvent('ox_inventory:closeInventory', payload.source)
-        TriggerClientEvent('lab-Combine:Combine', payload.source)
-        Wait(2000)
-        ox_inventory:RemoveItem(payload.source, item1, 1)
-        ox_inventory:RemoveItem(payload.source, item2, 1)
-        ox_inventory:AddItem(payload.source, Combinations[item1].result, 1)
+
+        TriggerClientEvent('ox_inventory:closeInventory', data.source)
+        TriggerClientEvent('lab-Combine:Combine', data.source)
+
+        CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Recipies[item1.name].result}
+
         return false
     end
 end, {})
+
+
+lib.callback.register('lab-Combine:success', function(source, success)
+    local data = CraftQueue[source]
+
+    if not data then return end
+
+    if success then
+        ox_inventory:RemoveItem(source, data.item1, 1)
+        ox_inventory:RemoveItem(source, data.item2, 1)
+        ox_inventory:AddItem(source, data.result, 1)
+    end
+
+    CraftQueue[source] = nil
+end)

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -7,13 +7,23 @@ local Combinations = {
 }
 
 local combhook = ox_inventory:registerHook('swapItems', function(payload)
-    if  payload.fromSlot ~= nil and payload.toSlot ~= nil and Combinations[payload.fromSlot.name] ~= nil and payload.toSlot.name == Combinations[payload.fromSlot.name].needs then
+    if payload.fromSlot ~= nil and payload.toSlot ~= nil then
+        local item1 = (Combinations[payload.fromSlot.name] and payload.fromSlot.name) or (Combinations[payload.toSlot.name] and payload.toSlot.name)
+
+        if not item1 then return end
+
+        local item2 = (Combinations[item1].needs == payload.fromSlot.name and payload.fromSlot.name) or (Combinations[item1].needs == payload.toSlot.name and payload.toSlot.name)
+        if not item2 then return end
+
+        if Combinations[payload.fromSlot.name] then
+            item1 = payload.fromSlot.name
+        end
         TriggerClientEvent('ox_inventory:closeInventory', payload.source)
         TriggerClientEvent('lab-Combine:Combine', payload.source)
         Wait(2000)
-        ox_inventory:RemoveItem(payload.source, payload.fromSlot.name, 1)
-        ox_inventory:RemoveItem(payload.source, Combinations[payload.fromSlot.name].needs, 1)
-        ox_inventory:AddItem(payload.source, Combinations[payload.fromSlot.name].result, 1)
+        ox_inventory:RemoveItem(payload.source, item1, 1)
+        ox_inventory:RemoveItem(payload.source, item2, 1)
+        ox_inventory:AddItem(payload.source, Combinations[item1].result, 1)
         return false
     end
-end,{})
+end, {})

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -43,7 +43,7 @@ local craftHook = exports.ox_inventory:registerHook('swapItems', function(data)
             TriggerClientEvent('ox_lib:notify', data.source,
             {
                 type = 'error',
-                description = ("Not enough %s. Need %.0f"):format(item2.label, Recipies[item1.name].amount[item2.name])
+                description = ("Not enough %s. Need %.0f"):format(item2.label, Combinations[item1.name].amount[item2.name])
             })
             return false
         end
@@ -51,7 +51,7 @@ local craftHook = exports.ox_inventory:registerHook('swapItems', function(data)
         TriggerClientEvent('ox_inventory:closeInventory', data.source)
         TriggerClientEvent('lab-Combine:Combine', data.source)
 
-        CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Recipies[item1.name].result}
+        CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Combinations[item1.name].result}
 
         return false
     end

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -19,7 +19,7 @@ local Combinations = { --create new item craft Recipies here. limited to 2 items
     
 }
 
-local craftHook = exports.ox_inventory:registerHook('swapItems', function(data)
+local craftHook = ox_inventory:registerHook('swapItems', function(data)
     if type(data.fromSlot) == "table" and type(data.toSlot) == "table" then
 
         if data.fromSlot?.name == data.toSlot?.name then return end

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -49,7 +49,7 @@ local craftHook = ox_inventory:registerHook('swapItems', function(data)
         end
 
         TriggerClientEvent('ox_inventory:closeInventory', data.source)
-        TriggerClientEvent('lab-Combine:Combine', data.source)
+        TriggerClientEvent('lab-Combine:Combine', data.source, Combinations[item1.name].duration)
 
         CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Combinations[item1.name].result}
 

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -17,9 +17,17 @@ local Combinations = { --create new item craft Recipies here. limited to 2 items
         result = 'packagedmeth' -- the item you get after craft
     },
 
+
+    ['garbage'] = { --item1
+        otherItem = 'scrapmetal', --item2
+        duration = 2000, --how long the craft takes
+        result = 'lockpick', -- the item you get after craft
+        amount = {['garbage'] = 1, ['scrapmetal'] = 2, ['lockpick'] = 2}, --amount of both items needed to craft and then how many of the crafted item it makes. must match item1, item2, result
+    },
+
 }
 
----@type table<number, {item1: string, item2: string, result: string}>
+---@type table<number, table<string, {name: string, amount: number}>>
 local CraftQueue = {}
 
 local craftHook = ox_inventory:registerHook('swapItems', function(data)
@@ -30,7 +38,8 @@ local craftHook = ox_inventory:registerHook('swapItems', function(data)
         local item1 = (Combinations[data.fromSlot?.name] and data?.fromSlot) or (Combinations[data.toSlot?.name] and data.toSlot)
         if not item1 then return end
 
-        if Combinations[item1.name].amount[item1.name] > item1.count then
+        local amount1 = Combinations[item1.name].amount[item1.name]
+        if amount1 > ox_inventory:GetItem(data.source, item1.name, nil, true)  then
             TriggerClientEvent('ox_lib:notify', data.source,
             {
                 type = 'error',
@@ -42,7 +51,8 @@ local craftHook = ox_inventory:registerHook('swapItems', function(data)
         local item2 = (Combinations[item1.name].otherItem == data.fromSlot.name and data.fromSlot) or (Combinations[item1.name].otherItem == data.toSlot.name and data.toSlot)
         if not item2 then return end
 
-        if Combinations[item1.name].amount[item2.name] > item2.count then
+        local amount2 = Combinations[item1.name].amount[item2.name]
+        if amount2 > ox_inventory:GetItem(data.source, item2.name, nil, true) then
             TriggerClientEvent('ox_lib:notify', data.source,
             {
                 type = 'error',
@@ -50,10 +60,16 @@ local craftHook = ox_inventory:registerHook('swapItems', function(data)
             })
             return false
         end
-        print("craft")
+
         TriggerClientEvent('lab-Combine:Combine', data.source, Combinations[item1.name].duration)
 
-        CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Combinations[item1.name].result}
+        local resultItem = Combinations[item1.name].result
+
+        CraftQueue[data.source] = {
+            item1 = {name = item1.name, amount = amount1},
+            item2 = {name = item2.name, amount = amount2},
+            result = {name = resultItem, amount = Combinations[item1.name].amount[resultItem]}
+        }
 
         return false
     end
@@ -66,9 +82,9 @@ lib.callback.register('lab-Combine:success', function(source, success)
     if not data then return end
 
     if success then
-        ox_inventory:RemoveItem(source, data.item1, 1)
-        ox_inventory:RemoveItem(source, data.item2, 1)
-        ox_inventory:AddItem(source, data.result, 1)
+        ox_inventory:RemoveItem(source, data.item1.name, data.item1.amount)
+        ox_inventory:RemoveItem(source, data.item2.name, data.item2.amount)
+        ox_inventory:AddItem(source, data.result.name, data.result.amount)
     end
 
     CraftQueue[source] = nil

--- a/lab-Combine/server.lua
+++ b/lab-Combine/server.lua
@@ -4,20 +4,23 @@ local ox_inventory = exports.ox_inventory
 local Combinations = { --create new item craft Recipies here. limited to 2 items per craft, but you can have multiple of each of those 2 items if desired
 
     ['coca'] = { --item1
-	otherItem = 'baggy', --item2
-        amount = {['baggy'] = 1, ['coca'] = 1}, --amount of each item needed to craft. must match item1 and item2
+	    otherItem = 'baggy', --item2
+        amount = {['coca'] = 1, ['baggy'] = 1}, --amount of each item needed to craft. must match item1 and item2
         duration = 2000, --how long the craft takes
         result = 'coke' -- the item you get after craft
     },
-	
+
     ['meth'] = { --item1
-	otherItem = 'baggy', --item2
+	    otherItem = 'baggy', --item2
         amount = {['baggy'] = 1, ['meth'] = 1}, --amount of each item needed to craft. must match item1 and item2
         duration = 2000, --how long the craft takes
         result = 'packagedmeth' -- the item you get after craft
     },
-    
+
 }
+
+---@type table<number, {item1: string, item2: string, result: string}>
+local CraftQueue = {}
 
 local craftHook = ox_inventory:registerHook('swapItems', function(data)
     if type(data.fromSlot) == "table" and type(data.toSlot) == "table" then
@@ -47,8 +50,7 @@ local craftHook = ox_inventory:registerHook('swapItems', function(data)
             })
             return false
         end
-
-        TriggerClientEvent('ox_inventory:closeInventory', data.source)
+        print("craft")
         TriggerClientEvent('lab-Combine:Combine', data.source, Combinations[item1.name].duration)
 
         CraftQueue[data.source] = {item1 = item1.name, item2 = item2.name, result = Combinations[item1.name].result}


### PR DESCRIPTION
this little rewrite i did of the system will allow players to drag the items both ways to craft without having multiple table entries. ex: drag meth onto baggy and baggy onto meth = same result.

you can set amount of each item needed to craft also. ex: 3 meth and 1 baggy

also i changed the wait on the server side to a callback that gets called after the crafting bar. that way we arent prolonging the hook and causing any warnings or issues with the inventory. this change also allows a player to cancel the crafting progress bar and cancel the craft along with it